### PR TITLE
Удалит пакет `@types/react-router-dom`

### DIFF
--- a/template.json
+++ b/template.json
@@ -30,7 +30,6 @@
       "@types/react-dom": "^17.0.0",
       "@types/faker": "5.5.8",
       "@types/react-redux": "^7.1.18",
-      "@types/react-router-dom": "^5.1.9",
       "axios-mock-adapter": "1.19.0",
       "eslint-config-htmlacademy": "^4.1.0",
       "faker": "5.5.3",


### PR DESCRIPTION
После обновления пакета `react-router-dom`, в пакете `@types/react-router-dom` нет необходимости. 